### PR TITLE
Fixed run/next/prev methods

### DIFF
--- a/src/smartour.ts
+++ b/src/smartour.ts
@@ -146,9 +146,9 @@ export default class Smartour {
     return this
   }
 
-  run (isNext: boolean = true) {
+  run () {
     if (this.tourListLength && this.tourIndex < this.tourListLength - 1) {
-      isNext ? this.tourIndex++ : this.tourIndex--
+      this.tourIndex++
       const tour = this.tourList[this.tourIndex]
       if (tour.options) {
         this.options = { ...this.options, ...tour.options }
@@ -160,11 +160,16 @@ export default class Smartour {
   }
 
   next () {
-    this.run(true)
+    this.run()
   }
 
   prev () {
-    this.run(false)
+    if (this.tourIndex !== 0) this.tourIndex--
+    const tour = this.tourList[this.tourIndex]
+    if (tour.options) {
+      this.options = { ...this.options, ...tour.options }
+    }
+    this._show(tour.el, tour.slot, tour.keyNodes)
   }
 
   over () {


### PR DESCRIPTION
Thank you so much for your work!

I encountered a small error. In the current version, you can't use the prev() method if we are on the last slide.

https://github.com/jrainlau/smartour/blob/master/src/smartour.ts#L150
this.tourIndex of the last slide will always be equal to this.tourListLength - 1 and the prev() method will not switch to the previous slide.

I suggest using the run() method to run and switch to the next slide, the code logic will remain the same for the next() method.

There will be a separate code for the prev() method with this.tourIndex guard so that it won't switch to a non-existent slide.